### PR TITLE
feat: Details page mock up layout

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@radix-ui/react-label": "^2.1.6",
         "@radix-ui/react-popover": "^1.1.13",
         "@radix-ui/react-select": "^2.2.4",
-        "@radix-ui/react-slot": "^1.2.2",
+        "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/vite": "^4.1.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1224,6 +1224,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1286,6 +1304,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1450,6 +1486,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.6.tgz",
@@ -1553,6 +1607,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.4.tgz",
@@ -1596,10 +1668,28 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-slot": {
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
       "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@radix-ui/react-label": "^2.1.6",
     "@radix-ui/react-popover": "^1.1.13",
     "@radix-ui/react-select": "^2.2.4",
-    "@radix-ui/react-slot": "^1.2.2",
+    "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import SearchPage from './pages/SearchPage';
 import ResultsPage from './pages/ResultsPage';
+import FlightDetailsPage from "@/pages/FlightDetailsPage";
 
 function App() {
     return (
@@ -8,6 +9,7 @@ function App() {
             <Routes>
                 <Route path="/" element={<SearchPage />} />
                 <Route path="/results" element={<ResultsPage />} />
+                <Route path="/details/:uuid" element={<FlightDetailsPage />} />
             </Routes>
         </Router>
     );

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+    "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-normal break-words shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow]",
+{
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/pages/FlightDetailsPage.tsx
+++ b/frontend/src/pages/FlightDetailsPage.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { format, parseISO } from 'date-fns';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+interface Amenity {
+    name: string;
+    chargeable: boolean;
+}
+
+interface Segment {
+    departureTime: string;
+    arrivalTime: string;
+    departureAirport: string;
+    departureIata: string;
+    arrivalAirport: string;
+    arrivalIata: string;
+    airlineCode: string;
+    airlineName: string;
+    flightNumber: string;
+    operatingAirlineCode: string | null;
+    operatingAirlineName: string | null;
+    aircraftType: string;
+    cabin: string;
+    travelClass: string;
+    amenities: Amenity[];
+}
+
+interface Layover {
+    airportName: string;
+    airportCode: string;
+    duration: string;
+}
+
+interface Fee {
+    type: string;
+    amount: string;
+}
+
+interface PriceBreakdown {
+    basePrice: string;
+    totalPrice: string;
+    fees: Fee[];
+    pricePerTraveler: string;
+}
+
+interface FlightDetailsResponse {
+    segments: Segment[];
+    layovers: Layover[];
+    priceBreakdown: PriceBreakdown;
+}
+
+export const FlightDetailsPage = () => {
+    const { uuid } = useParams();
+    const navigate = useNavigate();
+    const [data, setData] = useState<FlightDetailsResponse | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        const fetchDetails = async () => {
+            try {
+                const res = await fetch(`/api/flights/details/${uuid}`);
+                if (!res.ok) throw new Error('Not found');
+                const json = await res.json();
+                setData(json);
+            } catch (err) {
+                setError('Could not fetch flight details.');
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchDetails();
+    }, [uuid]);
+
+    const formatTime = (iso: string) => format(parseISO(iso), 'yyyy-MM-dd HH:mm');
+
+    if (loading) return <p className="text-center mt-10">Loading...</p>;
+    if (error || !data)
+        return (
+            <div className="text-center mt-10">
+                <p className="text-red-600">{error}</p>
+                <Button onClick={() => navigate('/')}>Back to Search</Button>
+            </div>
+        );
+
+    return (
+        <div className="max-w-7xl mx-auto py-8 px-4 ">
+            <Button
+                onClick={() => navigate(-1)}
+                variant="outline"
+                className="border-pink-600 hover:bg-pink-700 hover:text-white mb-6"
+            >
+                {"<-"} Back to Results
+            </Button>
+
+            <div className="flex text-3xl font-extrabold justify-center mb-8">
+                Flight Details
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <div className="md:col-span-2 space-y-4">
+                    {data.segments.map((segment, index) => (
+                        <div key={index}>
+                            <Card className="p-4 flex flex-col md:flex-row gap-4 justify-between border-pink-200 shadow-sm bg-pink-50/20">
+                                <div className="md:w-2/3 space-y-2">
+                                    <div className="text-sm font-bold text-pink-600">Segment {index + 1}</div>
+                                    <div className="text-md font-semibold">
+                                        {formatTime(segment.departureTime)} - {formatTime(segment.arrivalTime)}
+                                    </div>
+                                    <div className="text-lg">
+                                        <span className="font-semibold">
+                                            {segment.departureAirport} ({segment.departureIata})
+                                        </span>{' '} → {' '}
+                                        <span className="font-semibold">
+                                            {segment.arrivalAirport} ({segment.arrivalIata})
+                                        </span>
+                                    </div>
+                                    <div className="text-md text-gray-700 mt-6">
+                                        <span className="font-semibold text-pink-600">{segment.airlineName}</span> ({segment.airlineCode})
+                                        <div>
+                                            <span className={"text-black font-semibold"}>Flight number: </span> {segment.flightNumber}
+                                        </div>
+                                        {segment.operatingAirlineName && (
+                                            <>
+                                                {' '}
+                                                <span className="italic">
+                                                operated by {segment.operatingAirlineName} ({segment.operatingAirlineCode})
+                                                </span>
+                                            </>
+                                        )}
+                                    </div>
+                                    <div>
+                                        <span className="font-semibold">Aircraft Type:</span> {segment.aircraftType}
+                                    </div>
+                                </div>
+
+                                <div className="md:w-1/3 border p-3 rounded space-y-2 border-pink-300 bg-pink-50 break-words ">
+                                    <div className="font-semibold text-pink-600">Traveler Fare Details</div>
+                                    <div>Cabin: <span className="font-medium">{segment.cabin}</span></div>
+                                    <div>Class: <span className="font-medium">{segment.travelClass}</span></div>
+                                    <div>
+                                        <div >Amenities:</div>
+                                        <div className="flex flex-wrap gap-2">
+                                            {segment.amenities.map((amenity, i) => (
+                                                <Badge
+                                                    key={i}
+                                                    variant="outline"
+                                                    className="bg-white text-black border border-pink-300 text-sm font-normal px-3 py-1 leading-snug break-words whitespace-normal min-h-[2.25rem] max-w-xs w-full sm:w-fit"
+                                                >
+                                                    <div className="w-full break-words text-left">
+                                                        {amenity.name}{' '}
+                                                        <span className="text-pink-600 font-medium">
+                                                            {amenity.chargeable ? '(Chargeable)' : '(Free)'}
+                                                        </span>
+                                                    </div>
+                                                </Badge>
+                                            ))}
+                                        </div>
+
+
+                                    </div>
+                                </div>
+                            </Card>
+
+                            {index < data.layovers.length && (
+                                <div className="text-center italic text-black py-2 font-bold">
+                                    ✈️ Layover at {data.layovers[index].airportName} ({data.layovers[index].airportCode}) — {data.layovers[index].duration}
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
+
+
+                <div className="md:col-span-1 space-y-4">
+                    <Card className="p-4 space-y-2 border-pink-200 shadow-sm bg-pink-50/20">
+                        <div className="text-lg font-bold text-pink-600 mb-2">Price Breakdown</div>
+                        <div>Base Price: <span className="font-medium">${data.priceBreakdown.basePrice}</span></div>
+                        <div className="font-semibold mt-2 underline">Fees:</div>
+                        {data.priceBreakdown.fees.map((fee, idx) => (
+                            <div key={idx}>
+                                {fee.type}: <span className="font-medium">${fee.amount}</span>
+                            </div>
+                        ))}
+                        <div className="font-bold pt-2 border-t border-pink-200 text-lg text-pink-600">
+                            Total: ${data.priceBreakdown.totalPrice}
+                        </div>
+
+                        <Card className="p-3 mt-3 border-pink-200 bg-white">
+                            <div className="text-sm font-semibold text-gray-500">Price per Traveler:</div>
+                            <div className="text-md font-bold">${data.priceBreakdown.pricePerTraveler}</div>
+                        </Card>
+                    </Card>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default FlightDetailsPage;


### PR DESCRIPTION
Added a details page that can be called by a button on flight results to show detailed information of the flight such as:
Details of each segment (ordered by date/time):

- Departure time
- Arrival time
- Airline code and name
- Flight number
- If the flight is operated by different airline show the operating carrier code and name also
- Aircraft type
- Traveler fare details per segment:
  - Cabin
  - Class
  - The amenities:
    - Name of the amenity
    - If it is chargeable or not 
- Show the layover time between segments
- Display the price breakdown in a section in the right showing
  - Base price
  - Total price
  - Fees
  - Price per traveler